### PR TITLE
Fixed matrix dimension errors when running 21-gene network then 4-gene network

### DIFF
--- a/matlab/readInputSheet.m
+++ b/matlab/readInputSheet.m
@@ -52,11 +52,9 @@ for currentRow = 2:numRows
     end
 end
 
+GRNstruct = rmfield(GRNstruct, 'microData');
 % This reads the microarray data for each strain.
-
 for index = 1:length(Strain)
-    GRNstruct.microData(index).Strain = {};
-    GRNstruct.microData(index).deletion = {};
     currentStrain = strtrim(lower(Strain{index}));
     [GRNstruct.microData(index).data,GRNstruct.labels.TX1] = xlsread(input_file,[currentStrain '_log2_expression']);
     GRNstruct.microData(index).Strain = currentStrain;


### PR DESCRIPTION
There was a bug that showed up when I ran the 21-gene network and then the smaller gene network. The microData kept the genes from the 21-gene network instead of replacing them with the smaller network.